### PR TITLE
chore: add templates for issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Expected Behavior
+<!--- Tell us what should happen -->
+
+## Current Behavior
+<!--- Tell us what happens instead of the expected behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+* Version used:
+* Environment name and version (e.g. Chrome 39, node.js 5.4):
+* Operating System and version (desktop, server, or mobile):
+* Link to your project:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'enhancement'
+assignees: ''
+
+---
+
+<!--- Provide a general summary of the feature request in the Title above -->
+
+## Expected Behavior
+<!--- A clear and concise description of what you want to happen -->
+
+## Current Behavior
+<!--- Explain the difference from current behavior -->
+
+## Possible Solution
+<!--- Suggest ideas of how to implement the addition or change -->
+
+## Alternatives Considered
+<!--- A clear and concise description of any alternative solutions or features you've considered -->
+
+## Additional Context
+<!--- Add any other context or screenshots about the feature request here. -->
+
+


### PR DESCRIPTION
Adds 2 default issue templates: bugs and enhancements. Partial alternate to #1 that should not be very controversial.